### PR TITLE
The redirected page now will be automatically added to screens excluded for the security rules 

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -490,7 +490,7 @@ function compile(hook) {
     var redirectPageId = parseInt(hook.onErrorAction.page, 10);
     if (hook.filterType === 'whitelist') {
       comparison = '===';
-      if (redirectPageId & hook.pages.indexOf(redirectPageId) === -1) {
+      if (redirectPageId && hook.pages.indexOf(redirectPageId) === -1) {
         // Add the redirect page to the list of unprotected pages
         hook.pages.push(redirectPageId);
       }
@@ -499,7 +499,7 @@ function compile(hook) {
     if (hook.filterType === 'blacklist') {
       comparison = '>';
       var indexOfRedirect = hook.pages.indexOf(redirectPageId);
-      if (redirectPageId & indexOfRedirect > -1) {
+      if (redirectPageId && indexOfRedirect > -1) {
         // Remove the redirect page from the list of protected pages
         hook.pages.splice(indexOfRedirect, 1);
       }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/2793

## Description
Hooks weren't working because of syntax error.

## Screenshots/screencasts
![app-security](https://user-images.githubusercontent.com/52824207/72599545-95993480-391a-11ea-9892-2ca42dad1a2b.gif)

## Backward compatibility
This change is fully backward compatible.

## Notes
Also, I noticed that the dropdown is empty on load, I made this PR to fix it.https://github.com/Fliplet/fliplet-widget-link/pull/47 