### PR TITLE
Now in custom security rules protect rules are hidden

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -226,5 +226,5 @@
   border: 1px solid #e4e9eb;
   border-radius: 6px;
   min-height: 65px;
-  height: 150px;
+  height: 250px;
 }

--- a/js/interface.js
+++ b/js/interface.js
@@ -294,7 +294,7 @@ $(document)
         codeEditors[id].refresh();
       }
       $panel.find('.linkProvider').addClass('hidden');
-      $panel.find('.protect-app').removeClass('hidden');
+      $panel.find('.protect-app').addClass('hidden');
     }
 
     if (value !== 'custom') {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4199

## Description
As Nick mentioned in the comment, protect screen options in custom rule option are not needed. Also, I made custom rule textarea a bit larger.

## Screenshots/screencasts
![app-security](https://user-images.githubusercontent.com/52824207/74521479-22d3a700-4f22-11ea-9356-b9d45771dcf7.gif)

## Backward compatibility
This change is fully backward compatible.