### PR TITLE
XOR-494 [FIX] Ensure App Settings: Screen Security rule tile should not jerk on the screen when setting it up in Studio

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -3,7 +3,7 @@
   width: 100%;
 }
 
-body{
+body {
   overflow-y: hidden;
 }
 

--- a/css/interface.css
+++ b/css/interface.css
@@ -3,6 +3,10 @@
   width: 100%;
 }
 
+body{
+  overflow-y: hidden;
+}
+
 .spinner-holder {
   text-align: center;
 }


### PR DESCRIPTION
**Product areas affected**

Studio -> App Settings -> App Security

**What does this PR do?**

Implemented code so App Settings: Screen Security rule tile should not jerk on the screen when setting it up in Studio

**JIRA ticket**

[click here](https://weboo.atlassian.net/browse/XOR-494)

**Result**

https://github.com/Fliplet/fliplet-widget-app-security/assets/108272606/cf9c7b95-212d-42c2-892f-77a4bd1d139e

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None
