### PR TITLE
ID-4114 [Fix] Added special check for app preview

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -561,6 +561,7 @@ function compile(hook) {
 
     return [
       'if ([' + hook.pages + '].indexOf(page.id) ' + comparison + ' -1 && ',
+      'session.client.source !== \'studio\' && ',
       '(!session || !session.server.passports || !session.server.passports.' + hook.requirement + ')',
       hook.customCondition ? ' && ' + hook.customCondition : '',
       ')',

--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "App Security",
   "package": "com.fliplet.app-security",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icon": "img/icon.png",
   "tags": ["type:appComponent"],
   "provider_only": true,


### PR DESCRIPTION
This PR ensures that during app preview screen security rule for viewing screen is disabled otherwise it will lead to infinite screen loading when used with fliplet login widget.