### PR TITLE
PS-781 [FIX] fix studio check to enable security in preview

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -561,7 +561,6 @@ function compile(hook) {
 
     return [
       'if ([' + hook.pages + '].indexOf(page.id) ' + comparison + ' -1 && ',
-      'session.client.source !== \'studio\' && ',
       '(!session || !session.server.passports || !session.server.passports.' + hook.requirement + ')',
       hook.customCondition ? ' && ' + hook.customCondition : '',
       ')',


### PR DESCRIPTION
This PR ensures that during app preview screen security rule is enforced instead of allowing user to move to protected screen.