### PR TITLE
fix(DEV-1068): add onErrorAction.page reference for clone remapping

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -5,7 +5,7 @@
   "icon": "img/icon.png",
   "tags": ["type:appComponent"],
   "provider_only": true,
-  "references": [],
+  "references": ["onErrorAction.page:page"],
   "html_tag": "div",
   "interface": {
     "dependencies": [


### PR DESCRIPTION
## Summary
- Add `onErrorAction.page:page` to top-level `references` array in widget.json

Declares the error redirect page reference so `widgetInstance.updateReferences` can remap it during clone.

## Test plan
- [ ] Clone an app with app security configured with an error redirect page
- [ ] Verify the cloned app's security widget `onErrorAction.page` points to the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)